### PR TITLE
spelfout fix

### DIFF
--- a/resources/js/components/CreatePackage.vue
+++ b/resources/js/components/CreatePackage.vue
@@ -74,7 +74,7 @@
                     v-model="avg_confirmed"
                     id="checkboxes-4"
                     value="1"
-                  >Ik ga accoord met voorwaarden</b-form-checkbox>
+                  >Ik ga akkoord met voorwaarden</b-form-checkbox>
                 </b-form-group>
               </tab-content>
               <tab-content>

--- a/resources/js/components/CreatePackage.vue
+++ b/resources/js/components/CreatePackage.vue
@@ -81,7 +81,7 @@
                 <b-form-group
                   class="text-justify"
                   id="input-group-7"
-                  label="Breette:"
+                  label="Breedte:"
                   label-for="input-7"
                   for="width"
                 >


### PR DESCRIPTION
accoord spelt men tegenwoordig als 'akkoord'